### PR TITLE
輪読会は状態にかかわらずupdated_at descでorderされるようにした

### DIFF
--- a/app/models/reading_club.rb
+++ b/app/models/reading_club.rb
@@ -27,7 +27,7 @@ class ReadingClub < ApplicationRecord
       if is_requested_open
         sort_participating_first(clubs, user)
       else
-        clubs.order(created_at: :desc)
+        clubs.order(updated_at: :desc)
       end.to_a
     end
 

--- a/test/models/reading_club_test.rb
+++ b/test/models/reading_club_test.rb
@@ -22,9 +22,9 @@ class ReadingClubTest < ActiveSupport::TestCase
     result = search_query.result.includes(:participants)
 
     expected = [
-      reading_clubs(:finished_reading_club2),
+      reading_clubs(:finished_reading_club20),
       reading_clubs(:finished_reading_club12),
-      reading_clubs(:finished_reading_club20)
+      reading_clubs(:finished_reading_club2)
     ]
 
     actual =

--- a/test/system/reading_clubs_test.rb
+++ b/test/system/reading_clubs_test.rb
@@ -26,7 +26,7 @@ class ReadingClubsTest < ApplicationSystemTestCase
     end
     assert_text '輪読会に参加しました！'
 
-    within(find('li', text: 'OpenClub 20')) do
+    within(find('li', text: 'OpenClub 9')) do
       click_link '参加'
       click_link '参加取消'
     end


### PR DESCRIPTION
・updateがある方が、直近まで活動があった輪読会だと考えらえるため、topに見えた方が使いやすい