### PR TITLE
ノート検索フォームの日付範囲検索、クリアボタンを消した

### DIFF
--- a/app/views/reading_clubs/overview/notes/_search_form.html.slim
+++ b/app/views/reading_clubs/overview/notes/_search_form.html.slim
@@ -10,26 +10,8 @@
   ) do |f|
 
   .mr-2.mb-2.p-3.bg-gray-100.rounded-md
-    .flex.flex-col.md:flex-row.gap-1
-      = f.date_field :held_on_gteq,
-        class: 'mt-1 rounded-md'
-
-      span.items-center.text-gray-500.text-xl.font-bold
-        | ~
-
-      = f.date_field :held_on_lteq,
-        class: 'mt-1 rounded-md'
-
       = f.search_field :title_cont,
         placeholder: '輪読会のタイトルで検索',
-        class: 'mr-1 flex-grow h-8 p-2 \
+        class: 'h-8 p-2 w-full \
                 border-gray-300 rounded-md \
                 focus:border-blue-500 focus:ring focus:ring-blue-200'
-
-      .flex.justify-end
-        = link_to 'クリア',
-          reading_club_overview_path,
-          class: 'p-2 \
-                  text-white text-xs \
-                  bg-gray-400 rounded-md \
-                  hover:bg-red-600 focus:ring focus:ring-red-200'


### PR DESCRIPTION
・日付範囲を行うことがまずないので削除
・タイトル検索フォームにクリア(×ボタン)があるのでクリアボタンを削除