### PR TITLE
Fix/linter and rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ require:
   - rubocop-rails
 
 AllCops:
-  TargetRubyVersion: 3.3
+  TargetRubyVersion: 3.4.2
   NewCops: disable
   SuggestExtensions: false
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,7 +20,6 @@ AllCops:
     - 'storage/**/*'
     - 'tmp/**/*'
     - 'bin/**/*'
-    - 'app/helpers/application_helper.rb'
 
 Metrics/ClassLength:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,7 +21,6 @@ AllCops:
     - 'tmp/**/*'
     - 'bin/**/*'
     - 'app/helpers/application_helper.rb'
-    - 'app/helpers/reading_club_helper.rb' # 要検討
 
 Metrics/ClassLength:
   Exclude:

--- a/.slim-lint.yml
+++ b/.slim-lint.yml
@@ -1,5 +1,10 @@
 exclude:
-  - 'app/views/reading_clubs/overview/notes/_notes.html.slim' # https://github.com/sds/slim-lint/issues/101 と似ている現象
+  # 以下のエラーが発生する。調査&修正ができるまでは一時的にexclude
+  # app/views/reading_clubs/overview/notes/_notes.html.slim:4 [W] RuboCop: Lint/Syntax: unexpected token kDO_BLOCK
+  # app/views/reading_clubs/overview/notes/_notes.html.slim:15 [W] RuboCop: Lint/Syntax: unexpected token kDO_BLOCK
+  # app/views/reading_clubs/overview/notes/_notes.html.slim:16 [W] RuboCop: Lint/Syntax: unexpected token tSTRING
+  # app/views/reading_clubs/overview/notes/_notes.html.slim:18 [W] RuboCop: Lint/Syntax: unexpected token kEND
+  - 'app/views/reading_clubs/overview/notes/_notes.html.slim'
 
 linters:
   LineLength:

--- a/.slim-lint.yml
+++ b/.slim-lint.yml
@@ -1,7 +1,6 @@
 exclude:
   - 'app/views/reading_clubs/overview/notes/_notes.html.slim' # https://github.com/sds/slim-lint/issues/101 と似ている現象
-  - 'app/views/layouts/application.html.slim'
 
 linters:
   LineLength:
-    max: 120
+    max: 250

--- a/.slim-lint.yml
+++ b/.slim-lint.yml
@@ -1,5 +1,4 @@
 exclude:
-  - 'app/views/reading_clubs/overview.html.slim' # https://github.com/sds/slim-lint/issues/101 と似ている現象
   - 'app/views/reading_clubs/overview/notes/_notes.html.slim' # https://github.com/sds/slim-lint/issues/101 と似ている現象
   - 'app/views/layouts/application.html.slim'
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  # rubocop:disable Metrics/MethodLength, Layout/LineLength
+  # meta_tagが多く、description部分でどうしてもメソッドが長くなってしまうため、上記のrubocopルールを除外
   def default_meta_tags
     {
       site: 'BookRIn',
@@ -27,4 +29,5 @@ module ApplicationHelper
       }
     }
   end
+  # rubocop:enable Metrics/MethodLength, Layout/LineLength
 end

--- a/app/helpers/reading_club_helper.rb
+++ b/app/helpers/reading_club_helper.rb
@@ -11,13 +11,15 @@ module ReadingClubHelper
   end
 
   def participant_link(user, reading_club)
-    if participant = user.participants.find_by(reading_club:)
-      link_to '参加取消', participant_path(participant), data: { turbo_method: :delete },
-      class: "underline cursor-pointer text-gray-600"
+    if (participant = user.participants.find_by(reading_club:))
+      link_to '参加取消', participant_path(participant),
+              data: { turbo_method: :delete }, class: 'underline cursor-pointer text-gray-600'
     else
-      link_to '＋ 輪読会に参加する', reading_club_participants_path(reading_club), data: { turbo_method: :post },
-      class: "items-center px-4 py-2 cursor-pointer border border-link-border rounded-lg
-              text-white bg-main-color hover:bg-blue-700"
+      link_to '＋ 輪読会に参加する',
+              reading_club_participants_path(reading_club),
+              data: { turbo_method: :post },
+              class: 'items-center px-4 py-2 cursor-pointer border
+                border-link-border rounded-lg text-white bg-main-color hover:bg-blue-700'
     end
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -16,7 +16,7 @@ class UserTest < ActiveSupport::TestCase
     assert user.participating?(reading_club)
 
     Participant.find_by(user:, reading_club:).destroy!
-    refute user.participating?(reading_club)
+    assert_not user.participating?(reading_club)
   end
 
   test '.find_or_create_from_discord_info finds existing user' do


### PR DESCRIPTION
- [x] 不要にrubocop/slim-lintの監視対象から除外していたファイルを、監視対象に戻すようにした