### PR TITLE
NoteEditor部分は、API + Reactに書き換える

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'cssbundling-rails'
 # gem "bcrypt", "~> 3.1.7"
 
 gem 'dotenv-rails'
+gem 'jbuilder'
 gem 'kaminari'
 gem 'meta-tags'
 gem 'omniauth-discord'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,9 @@ GEM
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    jbuilder (2.13.0)
+      actionview (>= 5.0.0)
+      activesupport (>= 5.0.0)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
     json (2.10.2)
@@ -398,6 +401,7 @@ DEPENDENCIES
   dockerfile-rails (>= 1.7)
   dotenv-rails
   html2slim!
+  jbuilder
   jsbundling-rails
   kaminari
   meta-tags


### PR DESCRIPTION
https://github.com/masyuko0222/BookRIn/issues/146

RailsのViewもREactも使っていて、propsの受け渡しが多く複雑になっているため。