### PR TITLE
store_locationをAuthentication Moduleに移動

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,14 +3,6 @@
 class ApplicationController < ActionController::Base
   include Authentication
   helper_method :current_user
-  before_action :store_location
   before_action :require_user_login
-
-  def store_location
-    return unless request.get?
-    return if request.xhr?
-    return if request.path.in?([login_path, '/auth/discord/callback', '/auth/failure'])
-
-    session[:previous_url] = request.fullpath
-  end
+  before_action :store_location
 end

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -22,6 +22,14 @@ module Authentication
     @current_user = nil
   end
 
+  def store_location
+    return unless request.get?
+    return if request.xhr?
+    return if request.path.in?([login_path, '/auth/discord/callback', '/auth/failure'])
+
+    session[:previous_url] = request.fullpath
+  end
+
   private
 
   def logged_in?


### PR DESCRIPTION
・他のセッション関係のメソッドは、Authentication Moduleにまとめているため